### PR TITLE
metrics: make metrics optional under crate feature

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,6 +18,7 @@ scylla = { path = "../scylla", features = [
     "num-bigint-03",
     "num-bigint-04",
     "bigdecimal-04",
+    "metrics",
 ] }
 tokio = { version = "1.34", features = ["full"] }
 tracing = { version = "0.1.25", features = ["log"] }

--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -39,6 +39,7 @@ full-serialization = [
     "num-bigint-04",
     "bigdecimal-04",
 ]
+metrics = ["dep:histogram"]
 
 [dependencies]
 scylla-macros = { version = "0.7.0", path = "../scylla-macros" }
@@ -47,7 +48,7 @@ byteorder = "1.3.4"
 bytes = "1.0.1"
 futures = "0.3.6"
 hashbrown = "0.14"
-histogram = "0.6.9"
+histogram = { version = "0.6.9", optional = true }
 tokio = { version = "1.34", features = [
     "net",
     "time",

--- a/scylla/src/lib.rs
+++ b/scylla/src/lib.rs
@@ -286,4 +286,5 @@ pub use transport::load_balancing;
 pub use transport::retry_policy;
 pub use transport::speculative_execution;
 
+#[cfg(feature = "metrics")]
 pub use transport::metrics::{Metrics, MetricsError};

--- a/scylla/src/transport/mod.rs
+++ b/scylla/src/transport/mod.rs
@@ -10,6 +10,7 @@ pub mod iterator;
 pub mod legacy_query_result;
 pub mod load_balancing;
 pub mod locator;
+#[cfg(feature = "metrics")]
 pub(crate) mod metrics;
 mod node;
 pub mod partitioner;

--- a/scylla/src/transport/speculative_execution.rs
+++ b/scylla/src/transport/speculative_execution.rs
@@ -3,15 +3,19 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
 };
 use scylla_cql::frame::response::error::DbError;
-use std::{future::Future, sync::Arc, time::Duration};
+#[cfg(feature = "metrics")]
+use std::sync::Arc;
+use std::{future::Future, time::Duration};
 use tracing::{trace_span, warn, Instrument};
 
 use crate::transport::errors::QueryError;
 
+#[cfg(feature = "metrics")]
 use super::metrics::Metrics;
 
 /// Context is passed as an argument to `SpeculativeExecutionPolicy` methods
 pub struct Context {
+    #[cfg(feature = "metrics")]
     pub metrics: Arc<Metrics>,
 }
 
@@ -66,6 +70,7 @@ impl SpeculativeExecutionPolicy for PercentileSpeculativeExecutionPolicy {
         self.max_retry_count
     }
 
+    #[cfg(feature = "metrics")]
     fn retry_interval(&self, context: &Context) -> Duration {
         let interval = context.metrics.get_latency_percentile_ms(self.percentile);
         let ms = match interval {
@@ -79,6 +84,12 @@ impl SpeculativeExecutionPolicy for PercentileSpeculativeExecutionPolicy {
             }
         };
         Duration::from_millis(ms)
+    }
+
+    #[cfg(not(feature = "metrics"))]
+    fn retry_interval(&self, _: &Context) -> Duration {
+        warn!("PercentileSpeculativeExecutionPolicy requires the 'metrics' feature to work as intended, defaulting to 100 ms");
+        Duration::from_millis(100)
     }
 }
 


### PR DESCRIPTION
<!--
I've added "metrics" crate feature which enables usage and gathering of metrics.

Therefore everyone willing to use metrics in their code is required to add "metrics" feature in their `Cargo.toml` file or compile otherwise with `--features metrics` flag.

This change was requested in #330

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~
-->
